### PR TITLE
Check input as string value

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,7 +76,7 @@ function formatReleaseMessage(releaseNumber) {
 }
 
 function addExtraFlagCleanCache(gigalixirClean) {
-  return gigalixirClean ? ` -c http.extraheader="GIGALIXIR-CLEAN: true" ` : ""
+  return (gigalixirClean === "true") ? ` -c http.extraheader="GIGALIXIR-CLEAN: true" ` : ""
 }
 
 async function run() {


### PR DESCRIPTION
Prevents action from always sending clean headers.